### PR TITLE
Constraint value refactor

### DIFF
--- a/pesukarhu/ecs/systems/ui/ConstraintSystem.cpp
+++ b/pesukarhu/ecs/systems/ui/ConstraintSystem.cpp
@@ -53,7 +53,7 @@ namespace pk
                     switch (horizontalType)
                     {
                         case HorizontalConstraintType::PIXEL_LEFT:		        tMat[0 + 3 * 4] = horizontalVal; break;
-                        case HorizontalConstraintType::PIXEL_RIGHT:		        tMat[0 + 3 * 4] = windowWidth - horizontalVal - transformWidth; break;
+                        case HorizontalConstraintType::PIXEL_RIGHT:		        tMat[0 + 3 * 4] = windowWidth + horizontalVal; break;
                         case HorizontalConstraintType::PIXEL_CENTER_HORIZONTAL:	tMat[0 + 3 * 4] = windowWidth * 0.5f + horizontalVal; break;
                         default:
                             break;
@@ -61,80 +61,14 @@ namespace pk
 
                     switch (verticalType)
                     {
-                        case VerticalConstraintType::PIXEL_BOTTOM:		        tMat[1 + 3 * 4] = verticalVal + transformHeight; break;
-                        case VerticalConstraintType::PIXEL_TOP:			tMat[1 + 3 * 4] = windowHeight - verticalVal;	break;
+                        case VerticalConstraintType::PIXEL_BOTTOM:		        tMat[1 + 3 * 4] = verticalVal; break;
+                        case VerticalConstraintType::PIXEL_TOP:			tMat[1 + 3 * 4] = windowHeight + verticalVal;	break;
                         case VerticalConstraintType::PIXEL_CENTER_VERTICAL:		tMat[1 + 3 * 4] = windowHeight * 0.5f + verticalVal; break;
                         default:
                             break;
                     }
                 }
             }
-            // ..or
-            /*
-            ComponentPool::iterator constraintIterator = constraintPool.begin();
-            ComponentPool::iterator transformIterator = transformPool.begin();
-
-            while (constraintIterator != constraintPool.end() && transformIterator != transformPool.end())
-            {
-                // TODO: make safer?
-                Component* pConstraintRaw = (Component*)constraintIterator.ptr;
-                Component* pTransformRaw = (Component*)transformIterator.ptr;
-                if (!(pConstraintRaw->isNull() && pTransformRaw->isNull()))
-                {
-                    ConstraintData* pConstraint = (ConstraintData*)pConstraintRaw;
-                    Transform* pTransform = (Transform*)pTransformRaw;
-                }
-                ++constraintIterator;
-                ++transformIterator;
-            }
-            */
         }
-
-        // OLD BELOW
-        // TODO: Make boundary checks and overall safer...
-        /*
-        void ConstraintSystem::update()
-        {
-            const Window* const win = Application::get()->getWindow();
-            const float windowWidth = win->getWidth();
-            const float windowHeight = win->getHeight();
-
-            Scene* pCurrentScene = Application::get()->accessCurrentScene();
-            // First find all relevant components..
-            std::vector<uint32_t> componentIds;
-            std::vector<ConstraintData*> pConstraintComponents;
-
-            if (pCurrentScene->typeComponentMapping.find(ComponentType::PK_UI_CONSTRAINT) != pCurrentScene->typeComponentMapping.end())
-            {
-                componentIds = pCurrentScene->typeComponentMapping[ComponentType::PK_UI_CONSTRAINT];
-                pConstraintComponents.reserve(componentIds.size());
-                for (uint32_t componentID : componentIds)
-                    pConstraintComponents.emplace_back((ConstraintData*)pCurrentScene->components[componentID]);
-            }
-
-            for (ConstraintData* pConstraintComponent : pConstraintComponents)
-            {
-                Transform* pTransform = (Transform*)(pCurrentScene->components[pConstraintComponent->transformID]);
-                mat4& tMat = pTransform->accessTransformationMatrix();
-
-                const float& transformWidth = tMat[0 + 0 * 4];
-                const float& transformHeight = tMat[1 + 1 * 4];
-
-                float constraintVal = pConstraintComponent->value;
-
-                switch (pConstraintComponent->constraintType)
-                {
-                    case ConstraintType::PIXEL_LEFT:		        tMat[0 + 3 * 4] = constraintVal; break;
-                    case ConstraintType::PIXEL_RIGHT:		        tMat[0 + 3 * 4] = windowWidth - constraintVal - transformWidth; break;
-                    case ConstraintType::PIXEL_BOTTOM:		        tMat[1 + 3 * 4] = constraintVal + transformHeight; break;
-                    case ConstraintType::PIXEL_TOP:			tMat[1 + 3 * 4] = windowHeight - constraintVal;	break;
-                    case ConstraintType::PIXEL_CENTER_HORIZONTAL:	tMat[0 + 3 * 4] = windowWidth * 0.5f + constraintVal; break;
-                    case ConstraintType::PIXEL_CENTER_VERTICAL:		tMat[1 + 3 * 4] = windowHeight * 0.5f + constraintVal; break;
-                    default:
-                        break;
-                }
-            }
-        }
-        */
     }
 }

--- a/pesukarhu/ui/Checkbox.cpp
+++ b/pesukarhu/ui/Checkbox.cpp
@@ -90,15 +90,7 @@ namespace pk
 
             // -> No fucking idea what that magic 4 comes from.. but seems good..
             //  ->same as with inputField...
-            if (constraintProperties.horizontalType == HorizontalConstraintType::PIXEL_RIGHT)
-            {
-                buttonDisplacement = 0;
-                infoDisplacement = defaultWidth + 4;
-            }
-            else
-            {
-                buttonDisplacement += ((float)pFont->getPixelSize()) - 4;
-            }
+            buttonDisplacement += ((float)pFont->getPixelSize()) - 4;
 
             ConstraintProperties backgroundImgConstraintProperties = constraintProperties;
             backgroundImgConstraintProperties.horizontalValue += buttonDisplacement;
@@ -122,10 +114,8 @@ namespace pk
             checkedImgConstraintProperties.horizontalValue = backgroundImgConstraintProperties.horizontalValue + checkedImgMinification * 0.5f;
 
             float checkedImgDisplacementY = checkedImgMinification * 0.5f;
-            if (backgroundImgConstraintProperties.verticalType == VerticalConstraintType::PIXEL_CENTER_VERTICAL)
-                checkedImgDisplacementY = -checkedImgMinification * 0.5f;
 
-            checkedImgConstraintProperties.verticalValue = backgroundImgConstraintProperties.verticalValue + checkedImgDisplacementY;
+            checkedImgConstraintProperties.verticalValue = backgroundImgConstraintProperties.verticalValue - checkedImgDisplacementY;
             GUIImage::ImgCreationProperties checkedImgProperties =
             {
                 checkedImgConstraintProperties,

--- a/pesukarhu/ui/GUIButton.cpp
+++ b/pesukarhu/ui/GUIButton.cpp
@@ -191,12 +191,7 @@ namespace pk
             const int txtDisplacementX = padding;
 
             ConstraintProperties useConstraintProperties = constraintProperties;
-
-            if (constraintProperties.horizontalType == HorizontalConstraintType::PIXEL_LEFT ||
-                constraintProperties.horizontalType == HorizontalConstraintType::PIXEL_CENTER_HORIZONTAL)
-                useConstraintProperties.horizontalValue += (float)txtDisplacementX;
-            else if (constraintProperties.horizontalType == HorizontalConstraintType::PIXEL_RIGHT)
-                useConstraintProperties.horizontalValue -= (float)txtDisplacementX;
+            useConstraintProperties.horizontalValue += (float)txtDisplacementX;
 
             _pText = new GUIText(
                 txt, font,

--- a/pesukarhu/ui/InputField.cpp
+++ b/pesukarhu/ui/InputField.cpp
@@ -180,21 +180,11 @@ namespace pk
                     pos += ((float)(glyph->advance >> 6));
                 }
             }
-            // TODO: Comment wtf happening here!!!!!!!
-            // NOTE: Still something fucked about this!!
-            //  -> No fucking idea what that magic 4 comes from.. but seems good..
+            // No fucking idea what that magic 4 comes from.. but seems good..
             float buttonDisplacementX = infoTxtWidth;
             float buttonDisplacementY = 0.0f;
             float infoDisplacement = 0;
-            if (constraintProperties.horizontalType == HorizontalConstraintType::PIXEL_RIGHT)
-            {
-                buttonDisplacementX = 0;
-                infoDisplacement = width + 4;
-            }
-            else
-            {
-                buttonDisplacementX += ((float)font.getPixelSize()) - 4;
-            }
+            buttonDisplacementX += ((float)font.getPixelSize()) - 4;
 
             ConstraintProperties buttonConstraintProperties = constraintProperties;
             buttonConstraintProperties.horizontalValue += buttonDisplacementX;

--- a/pesukarhu/ui/Panel.cpp
+++ b/pesukarhu/ui/Panel.cpp
@@ -470,22 +470,13 @@ namespace pk
             }
             else if (_layoutType == LayoutFillType::HORIZONTAL)
             {
-                pos = { (_slotScale.x + _slotPadding) * _elements.size(), 0.0f };
+                // NOTE: since negating pos from offset atm this needs to be negative on x
+                // so the x ends up being positive... quite fucked I know...
+                // TODO: Make this somehow clearer!
+                pos = { -(_slotScale.x + _slotPadding) * _elements.size(), 0.0f };
             }
 
-            if (_constraintProperties.verticalType == VerticalConstraintType::PIXEL_CENTER_VERTICAL)
-            {
-                pos.y *= -1.0f;
-                useOffset.y *= -1.0f;
-            }
-            else if (_constraintProperties.verticalType == VerticalConstraintType::PIXEL_BOTTOM)
-            {
-                pos.y *= -1.0f;
-                // -_slotScale.y since with bottom constraint the origin of element is its' bottom left corner
-                useOffset.y = _scale.y - useOffset.y - _slotScale.y;
-            }
-
-            return useOffset + pos;
+            return useOffset - pos;
         }
 
         void Panel::getRect(float& outX, float& outY, float& outWidth, float& outHeight) const
@@ -544,7 +535,7 @@ namespace pk
 
         int Panel::getVisibleVerticalSlots()
         {
-            return (_scale.y - _offsetFromPanel.y) / (_slotScale.y + _slotPadding);
+            return (_scale.y + _offsetFromPanel.y) / (_slotScale.y + _slotPadding);
         }
     }
 }

--- a/pesukarhu/ui/Panel.h
+++ b/pesukarhu/ui/Panel.h
@@ -60,7 +60,7 @@ namespace pk
             vec2 _slotScale;
             vec3 _color;
             // Padding to add from where elements get added
-            vec2 _offsetFromPanel = { 4.0f, 4.0f };
+            vec2 _offsetFromPanel = { 4.0f, -4.0f };
             int _slotCount = 0;
 
             Scrollbar* _pScrollbar = nullptr;
@@ -151,7 +151,7 @@ namespace pk
 
             void setActive(bool arg, entityID_t entity = 0);
 
-            void setLayer(int layer);
+            virtual void setLayer(int layer);
 
             // Returns current up to date pos and scale of the panel
             void getRect(float& outX, float& outY, float& outWidth, float& outHeight) const; // :D

--- a/pesukarhu/ui/Scrollbar.cpp
+++ b/pesukarhu/ui/Scrollbar.cpp
@@ -71,22 +71,16 @@ namespace pk
             _pPanel(pPanel)
         {
             const float defaultScrollbarWidth = 20.0f;
-            float scrollbarHeight = _pPanel->_scale.y - _pPanel->_offsetFromPanel.y;
+            float scrollbarHeight = _pPanel->_scale.y + _pPanel->_offsetFromPanel.y;
             vec2 buttonScale(defaultScrollbarWidth, defaultScrollbarWidth);
 
             // Create background img
             GUIImage::ImgCreationProperties scrollbarBackgroundProperties;
             scrollbarBackgroundProperties.constraintProperties = _pPanel->_constraintProperties;
-            VerticalConstraintType verticalConstraintType = _pPanel->_constraintProperties.verticalType;
-            float backgroundVerticalConstraintVal = _pPanel->_offsetFromPanel.y + buttonScale.y;
-            if (verticalConstraintType == VerticalConstraintType::PIXEL_CENTER_VERTICAL)
-                backgroundVerticalConstraintVal = -(_pPanel->_offsetFromPanel.y + buttonScale.y);
-            else if (verticalConstraintType == VerticalConstraintType::PIXEL_BOTTOM)
-                backgroundVerticalConstraintVal = _pPanel->_offsetFromPanel.y + buttonScale.y - topBarHeight;
 
-
+            float backgroundVerticalDisplacement = _pPanel->_offsetFromPanel.y - buttonScale.y;
             scrollbarBackgroundProperties.constraintProperties.horizontalValue += _pPanel->_scale.x - defaultScrollbarWidth - _pPanel->_offsetFromPanel.x;
-            scrollbarBackgroundProperties.constraintProperties.verticalValue += backgroundVerticalConstraintVal;
+            scrollbarBackgroundProperties.constraintProperties.verticalValue += backgroundVerticalDisplacement;
 
             scrollbarBackgroundProperties.width = defaultScrollbarWidth;
             scrollbarBackgroundProperties.height = scrollbarHeight - buttonScale.y * 2.0f;
@@ -103,7 +97,7 @@ namespace pk
             scrollPosImgProperties.constraintProperties = _pPanel->_constraintProperties;
 
             scrollPosImgProperties.constraintProperties.horizontalValue += _pPanel->_scale.x - defaultScrollbarWidth - _pPanel->_offsetFromPanel.x;
-            scrollPosImgProperties.constraintProperties.verticalValue  += backgroundVerticalConstraintVal;
+            scrollPosImgProperties.constraintProperties.verticalValue += backgroundVerticalDisplacement;
 
             scrollPosImgProperties.width = defaultScrollbarWidth;
             //scrollPosImgProperties.height = scrollbarHeight - buttonScale.y * 2.0f;
@@ -127,14 +121,8 @@ namespace pk
 
             // Up button
             ConstraintProperties upButtonConstraintProperties = _pPanel->_constraintProperties;
-            float upVerticalConstraintVal = _pPanel->_offsetFromPanel.y;
-            if (upButtonConstraintProperties.verticalType == VerticalConstraintType::PIXEL_CENTER_VERTICAL)
-                upVerticalConstraintVal = -_pPanel->_offsetFromPanel.y;
-            else if (upButtonConstraintProperties.verticalType == VerticalConstraintType::PIXEL_BOTTOM)
-                upVerticalConstraintVal = _pPanel->_scale.y - (_pPanel->_offsetFromPanel.y + buttonScale.y);
-
             upButtonConstraintProperties.horizontalValue += _pPanel->_scale.x - defaultScrollbarWidth - _pPanel->_offsetFromPanel.x;
-            upButtonConstraintProperties.verticalValue += upVerticalConstraintVal;
+            upButtonConstraintProperties.verticalValue += _pPanel->_offsetFromPanel.y;
 
             vec4 upTexCropping;
             upTexCropping.x = 0;
@@ -164,14 +152,9 @@ namespace pk
 
             // make the down button not be exactly on the bottom line...
             const float offsetFromBottom = 4.0f;
-            float downVerticalConstraintVal = _pPanel->_scale.y - buttonScale.y - offsetFromBottom;
-            if (downButtonConstraintProperties.verticalType == VerticalConstraintType::PIXEL_CENTER_VERTICAL)
-                downVerticalConstraintVal = -_pPanel->_scale.y + buttonScale.y + offsetFromBottom;
-            else if (downButtonConstraintProperties.verticalType == VerticalConstraintType::PIXEL_BOTTOM)
-                downVerticalConstraintVal = offsetFromBottom;
-
             downButtonConstraintProperties.horizontalValue += _pPanel->_scale.x - defaultScrollbarWidth - _pPanel->_offsetFromPanel.x;
-            downButtonConstraintProperties.verticalValue += downVerticalConstraintVal;
+            float downVerticalConstraintDisplacement = -_pPanel->_scale.y + buttonScale.y + offsetFromBottom;
+            downButtonConstraintProperties.verticalValue += downVerticalConstraintDisplacement;
 
             vec4 downTexCropping;
             downTexCropping.x = 1;
@@ -225,14 +208,7 @@ namespace pk
             ConstraintData* pBackgroundConstraint = _pBackgroundImg->getConstraint();
             ConstraintData* pIndicatorConstraintData = _pScrollPosImg->getConstraint();
 
-            float indicatorDisplacement = _scrollPos * stepSize;
-            if (pBackgroundConstraint->verticalType == VerticalConstraintType::PIXEL_CENTER_VERTICAL)
-                indicatorDisplacement = -_scrollPos * stepSize;
-
-            float indicatorVerticalVal = pBackgroundConstraint->verticalValue + indicatorDisplacement;
-            if (pBackgroundConstraint->verticalType == VerticalConstraintType::PIXEL_BOTTOM)
-                indicatorVerticalVal =  pBackgroundConstraint->verticalValue + backgroundHeight - indicatorHeight - indicatorDisplacement;
-
+            float indicatorVerticalVal = pBackgroundConstraint->verticalValue - (_scrollPos * stepSize);
             pIndicatorConstraintData->verticalValue = indicatorVerticalVal;
             pIndicatorConstraintData->horizontalValue = pBackgroundConstraint->horizontalValue;
 

--- a/pesukarhu/ui/TopBarPanel.cpp
+++ b/pesukarhu/ui/TopBarPanel.cpp
@@ -8,6 +8,9 @@ namespace pk
         void TopBarPanel::OnClickClose::onClick(InputMouseButtonName button)
         {
             _pPanel->close();
+            _pPanel->_pCloseButton->setActive(false);
+            _pPanel->_pTopBarImg->setActive(false);
+            _pPanel->_pTopBarTitle->setActive(false);
         }
 
 
@@ -42,17 +45,8 @@ namespace pk
             );
 
             // Create top bar
-            // If bottom constraint make this actually be on top
-            // (with bottom constraint positive values go from bottom to top)
-            float topBarConstraintValY = constraintProperties.verticalValue;
-            if (constraintProperties.verticalType == VerticalConstraintType::PIXEL_BOTTOM)
-            {
-                topBarConstraintValY += _scale.y - topBarHeight;
-            }
-
             GUIImage::ImgCreationProperties topBarCreationProperties;
             topBarCreationProperties.constraintProperties = constraintProperties;
-            topBarCreationProperties.constraintProperties.verticalValue = topBarConstraintValY;
             topBarCreationProperties.width = scale.x;
             topBarCreationProperties.height = topBarHeight;
             topBarCreationProperties.color = Panel::get_base_ui_color(2).toVec3();
@@ -61,7 +55,6 @@ namespace pk
 
             // Add title text
             ConstraintProperties titleConstraintProperties = constraintProperties;
-            titleConstraintProperties.verticalValue = topBarConstraintValY;
             _pTopBarTitle = new GUIText(title, *pFont, titleConstraintProperties);
 
             pScene->addChild(_entity, _pTopBarImg->getEntity());
@@ -72,7 +65,7 @@ namespace pk
                 constraintProperties.horizontalType,
                 constraintProperties.horizontalValue + scale.x - topBarHeight,
                 constraintProperties.verticalType,
-                topBarConstraintValY
+                constraintProperties.verticalValue
             };
             // Add close button
             _pCloseButton = new GUIButton(
@@ -91,16 +84,29 @@ namespace pk
             );
 
             // Make elements start after the top bar...
-            _offsetFromPanel.y += topBarHeight;
+            _offsetFromPanel.y -= topBarHeight;
 
             if (scrollable)
                 _pScrollbar = new Scrollbar(this, _pDefaultFont, topBarHeight);
+        }
+
+        void TopBarPanel::setLayer(int layer)
+        {
+            Panel::setLayer(layer);
+            _pTopBarImg->getRenderable()->setLayer(layer);
+            _pTopBarTitle->getRenderable()->setLayer(layer);
+            _pCloseButton->getImage()->getRenderable()->setLayer(layer);
+            _pCloseButton->getText()->getRenderable()->setLayer(layer);
         }
 
         void TopBarPanel::setComponentsActive(bool arg)
         {
             for(Component* pComponent : _pScene->getAllComponents(_entity))
                 pComponent->setActive(arg);
+
+            _pCloseButton->setActive(arg);
+            _pTopBarImg->setActive(arg);
+            _pTopBarTitle->setActive(arg);
         }
     }
 }

--- a/pesukarhu/ui/TopBarPanel.h
+++ b/pesukarhu/ui/TopBarPanel.h
@@ -37,6 +37,8 @@ namespace pk
                 bool scrollable = false
             );
 
+            void setLayer(int layer);
+
             virtual void open() {};
             virtual void close() {};
 

--- a/tests/src/UITestScene.cpp
+++ b/tests/src/UITestScene.cpp
@@ -18,12 +18,13 @@ void UITestScene::init()
     // Testing regular panel
     vec2 testPanelScale(300, 200);
     vec2 testPanelSlotScale(100, 24);
+    float verticalVal = testPanelScale.y;
     _testPanel.createDefault(
         this,
         _pDefaultFont,
         {
-            HorizontalConstraintType::PIXEL_RIGHT, 100.0f,
-            VerticalConstraintType::PIXEL_BOTTOM, 0
+            HorizontalConstraintType::PIXEL_RIGHT, -testPanelScale.x,
+            VerticalConstraintType::PIXEL_TOP, -120
         },
         testPanelScale,
         testPanelSlotScale,
@@ -31,8 +32,9 @@ void UITestScene::init()
     );
 
     _testPanel.addDefaultText("Testing");
-    _testPanel.addDefaultInputField("Input", 100, nullptr);
-    _testPanel.addDefaultCheckbox("Checking1");
+    _testPanel.addDefaultButton("Button", nullptr, 150);
+    _testPanel.addDefaultInputField("InputField", 150, nullptr);
+    _testPanel.addDefaultCheckbox("Checkbox");
 
     // Testing top bar panel
     vec2 testTopBarPanelScale(200, 175);
@@ -42,7 +44,7 @@ void UITestScene::init()
         "Top bar testing",
         {
             HorizontalConstraintType::PIXEL_CENTER_HORIZONTAL, 0.0f,
-            VerticalConstraintType::PIXEL_CENTER_VERTICAL, 0.0f
+            VerticalConstraintType::PIXEL_TOP, 0
         },
         testTopBarPanelScale,
         Panel::LayoutFillType::VERTICAL
@@ -50,17 +52,16 @@ void UITestScene::init()
     _topBarPanelTest.addDefaultButton("Button", nullptr, 100);
 
     // Testing scrollable panel
-    _scrollablePanel.initBase(
+    _scrollablePanel.createDefault(
         this,
         _pDefaultFont,
-        "Scrollable test",
         {
-            HorizontalConstraintType::PIXEL_LEFT, 300.0f,
-            VerticalConstraintType::PIXEL_BOTTOM, 0.0f
+            HorizontalConstraintType::PIXEL_RIGHT, -200,
+            VerticalConstraintType::PIXEL_BOTTOM, 320
         },
         { 200, 320 }, // scale
-        Panel::LayoutFillType::VERTICAL,
         testPanelSlotScale,
+        Panel::LayoutFillType::VERTICAL,
         true
     );
     for (int i = 0; i < 22; ++i)

--- a/tests/src/UITestScene.h
+++ b/tests/src/UITestScene.h
@@ -9,7 +9,7 @@ class UITestScene : public BaseScene
 private:
     pk::ui::Panel _testPanel;
     pk::ui::TopBarPanel _topBarPanelTest;
-    pk::ui::TopBarPanel _scrollablePanel;
+    pk::ui::Panel _scrollablePanel;
 
 public:
     UITestScene();


### PR DESCRIPTION
Made all constraint types interpret the "value" in same way.
* Positive horizontal value is always +x
* Positive vertical value is always +y (up)
* constraint 0,0 is always top left corner of the element
  -> This means that bottom vertical constraint value 0 expands the element out of bounds of the window. Same goes for right horizontal value 0.

This had to be done so we don't need some special cases for each different constraint type everywhere!